### PR TITLE
Use the first name when the username is missing from sender's info

### DIFF
--- a/gitter/scripts/yogi.coffee
+++ b/gitter/scripts/yogi.coffee
@@ -2,14 +2,14 @@ module.exports = (robot) ->
 
   robot.hear /(.*)/, (res) ->
   	parse_mode = "Markdown"
-  	chat_id = 
+  	chat_id =
   	token = ""
   	reqText = res.envelope.user.name + ' - ' + res.match[0]
   	robot.http("https://api.telegram.org/bot#{token}/sendMessage?parse_mode=#{parse_mode}&chat_id=#{chat_id}&text=" + reqText).get() (err,response,body) ->
   		# no response here since message is going to telegram
 
-	 robot.router.post '/hubot/gitter/:room' , (req, res) -> 
-	 	username = req.body.username
+	 robot.router.post '/hubot/gitter/:room' , (req, res) ->
+	 	username = (req.body.username != undefined) ? req.body.username : req.body.first_name;
 	 	console.log req.body
 	 	message = req.body.message
 	 	room = req.params.room


### PR DESCRIPTION
Currently bot sends a message with the username `undefined` if the username does not exist for the sender. 

In this case we should use the name of the sender. 
![screen shot 2018-04-11 at 8 59 45 pm](https://user-images.githubusercontent.com/12807846/38626971-6cd8f0ae-3dcb-11e8-81ec-a1be7f26fcc0.png)